### PR TITLE
[FIX] Show HTML as a image instead of raw HTML

### DIFF
--- a/client/src/components/atoms/Modal/Modal.tsx
+++ b/client/src/components/atoms/Modal/Modal.tsx
@@ -12,7 +12,7 @@ const Modal: React.FC<ModalProps> = ({
   hide,
   content,
 }: ModalProps) =>
-  isShowing
+  isShowing && content
     ? ReactDOM.createPortal(
         <React.Fragment>
           <div
@@ -27,7 +27,7 @@ const Modal: React.FC<ModalProps> = ({
             tabIndex={-1}
             role="dialog"
           >
-            <code>{content}</code>
+            <div dangerouslySetInnerHTML={{ __html: content }}></div>
           </div>
         </React.Fragment>,
         document.body


### PR DESCRIPTION
## ⚡️ What problem does this PR solve
Issue:  [Feature] Improve the display of the stored raw HTML content #23


## 🏗 How does this PR solve it
Show dangerouslySetInnerHTML instead of raw HTML
## 🖼 Screenshots or GIFs
<img width="1274" alt="Screen Shot 2022-10-14 at 22 33 17" src="https://user-images.githubusercontent.com/36767199/195885210-56a6fe0c-dee3-4421-aa19-ad78129210b0.png">


## 👌 Reviewer Checklist

- It meets acceptance criteria
- Coding style is adhered to
- Architecture is appropriate